### PR TITLE
Add dashboard counts and backend stats

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -223,7 +223,7 @@ def listar_reservas():
     reservas = Reserva.query.all()
     result = []
     for r in reservas:
-        result.append({'id': r.id, 'fecha': r.fecha, 'hora': r.hora, 'personas': r.personas, 'total': r.total})
+        result.append({'id': r.id, 'fecha': r.fecha, 'hora': r.hora, 'personas': r.personas, 'estado': r.estado, 'total': r.total})
     return jsonify(result)
 
 @app.route('/reservas/<int:id>', methods=['GET'])
@@ -312,6 +312,14 @@ def resumen_reserva(id):
         'mesa': {'numero': mesa.numero, 'ubicacion': mesa.ubicacion},
         'pedidos': pedidos
     })
+
+# ---------------------------- DASHBOARD STATS ---------------------------------
+@app.route('/dashboard/stats', methods=['GET'])
+def dashboard_stats():
+    pendientes = Reserva.query.filter_by(estado='Pendiente').count()
+    platos = Plato.query.count()
+    mesas = Mesa.query.count()
+    return jsonify({'reservas_pendientes': pendientes, 'platos': platos, 'mesas': mesas})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -21,6 +21,22 @@ if (!usuario) {
       window.location.href = 'index.html';
     });
   }
+
+  async function cargarEstadisticas() {
+    try {
+      const resp = await fetch('http://localhost:5000/dashboard/stats');
+      if (!resp.ok) return;
+      const datos = await resp.json();
+      const cards = document.querySelectorAll('.card');
+      if (cards[0]) cards[0].querySelector('.count').textContent = datos.reservas_pendientes;
+      if (cards[1]) cards[1].querySelector('.count').textContent = datos.platos;
+      if (cards[2]) cards[2].querySelector('.count').textContent = datos.mesas;
+    } catch (e) {
+      console.error('Error cargando estadísticas', e);
+    }
+  }
+
+  cargarEstadisticas();
 }
 
 


### PR DESCRIPTION
## Summary
- expose reservation `estado` in list API and add `/dashboard/stats` endpoint
- fetch counts from backend to show real-time numbers in dashboard

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687060536628832abeb332855641ec6e